### PR TITLE
Run Buildkite on Julia 1.6-nightly and Julia nightly

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,20 +1,4 @@
 steps:
-  - label: "Julia 1.5"
-    plugins:
-      - JuliaCI/julia#v0.6:
-          version: '1.5'
-    command: |
-      julia --project -e '
-        using Pkg
-        include(joinpath(".ci", "build.jl"))
-        Pkg.test(; coverage = false)'
-    agents:
-      queue: "juliagpu"
-      cuda: "*"
-      cap: "recent"
-    if: build.message !~ /\[skip tests\]/
-    timeout_in_minutes: 60
-    
   - label: "Julia 1.6-nightly"
     plugins:
       - JuliaCI/julia#v0.6:

--- a/README.md
+++ b/README.md
@@ -3,16 +3,16 @@
 [![Documentation (stable)][docs-stable-img]][docs-stable-url]
 [![Documentation (development)][docs-dev-img]][docs-dev-url]
 
-| Julia   | CUDA CI (Buildkite)                                                              |
-| ------- | -------------------------------------------------------------------------------- |
-| 1.5     | [![CUDA CI][ci-cuda-juliastable-img]][ci-cuda-juliastable-url]                   |
-| nightly | [![CUDA CI (Julia nightly)][ci-cuda-julianightly-img]][ci-cuda-julianightly-url] |
+| Julia           | CUDA CI (Buildkite)                                                              |
+| --------------- | -------------------------------------------------------------------------------- |
+| 1.6-nightly     | [![CUDA CI][ci-cuda-juliastable-img]][ci-cuda-juliastable-url]                   |
+| nightly         | [![CUDA CI (Julia nightly)][ci-cuda-julianightly-img]][ci-cuda-julianightly-url] |
 
 [docs-stable-img]: https://img.shields.io/badge/docs-stable-blue.svg "Documentation (stable)"
 [docs-stable-url]: https://JuliaLinearAlgebra.github.io/BLASBenchmarksGPU.jl/stable/
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg "Documentation (development)"
 [docs-dev-url]: https://JuliaLinearAlgebra.github.io/BLASBenchmarksGPU.jl/dev/
-[ci-cuda-juliastable-img]: https://badge.buildkite.com/6b5659c0fb69a540f4b5220c9a06eea10e4598463f9a7f95e9.svg?branch=master&step=Julia%201.5
+[ci-cuda-juliastable-img]: https://badge.buildkite.com/6b5659c0fb69a540f4b5220c9a06eea10e4598463f9a7f95e9.svg?branch=master&step=Julia%201.6-nightly
 [ci-cuda-juliastable-url]: https://buildkite.com/julialang/blasbenchmarksgpu-dot-jl
 [ci-cuda-julianightly-img]: https://badge.buildkite.com/6b5659c0fb69a540f4b5220c9a06eea10e4598463f9a7f95e9.svg?branch=master&step=Julia%20nightly
 [ci-cuda-julianightly-url]: https://buildkite.com/julialang/blasbenchmarksgpu-dot-jl


### PR DESCRIPTION
Once Julia 1.6.0 is released, we will change `Julia 1.6-nightly` to `Julia 1.6`.