### PR TITLE
Add a GFLOPS column to the DataFrame

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "BLASBenchmarksGPU"
 uuid = "7f126dfc-02fe-4b0a-bf44-dbfefac359c9"
 authors = ["Dilum Aluthge", "Chris Elrod", "Thomas Faingnaert", "Tim Besard", "contributors"]
-version = "0.1.2"
+version = "0.1.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"


### PR DESCRIPTION
At small matrix sizes, it makes more sense to talk about GFLOPS instead of TFLOPS.